### PR TITLE
Switch deflate implementation

### DIFF
--- a/internal/deflate/reader.go
+++ b/internal/deflate/reader.go
@@ -1,12 +1,12 @@
 package deflate
 
 import (
-	"compress/flate"
 	"errors"
 	"io"
 	"sync"
 
 	"github.com/bodgit/sevenzip/internal/util"
+	"github.com/klauspost/compress/flate"
 )
 
 //nolint:gochecknoglobals


### PR DESCRIPTION
From compress/flate to github.com/klauspost/compress/flate. Literally just an import swap, everything else is identical.

Benchmarks don't show much of a difference, peak rate is a smidge faster with newer implementation.

Fixes #25 