### PR TITLE
feat: optimize LZMA processing with enhanced multiReader implementation for io.ByteReader

### DIFF
--- a/internal/lzma/reader.go
+++ b/internal/lzma/reader.go
@@ -40,8 +40,7 @@ func NewReader(p []byte, s uint64, readers []io.ReadCloser) (io.ReadCloser, erro
 
 	h := bytes.NewBuffer(p)
 	_ = binary.Write(h, binary.LittleEndian, s)
-
-	lr, err := lzma.NewReader(io.MultiReader(h, readers[0]))
+	lr, err := lzma.NewReader(multiReader(h, readers[0]))
 	if err != nil {
 		return nil, err
 	}
@@ -50,4 +49,33 @@ func NewReader(p []byte, s uint64, readers []io.ReadCloser) (io.ReadCloser, erro
 		c: readers[0],
 		r: lr,
 	}, nil
+}
+
+func multiReader(b *bytes.Buffer, rc io.ReadCloser) io.Reader {
+	mr := io.MultiReader(b, rc)
+	if br, ok := rc.(io.ByteReader); ok {
+		return &multiByteReader{
+			b:  b,
+			br: br,
+			mr: mr,
+		}
+	}
+	return mr
+}
+
+type multiByteReader struct {
+	b  *bytes.Buffer
+	br io.ByteReader
+	mr io.Reader
+}
+
+func (m *multiByteReader) ReadByte() (byte, error) {
+	if m.b.Len() > 0 {
+		return m.b.ReadByte()
+	}
+	return m.br.ReadByte()
+}
+
+func (m *multiByteReader) Read(p []byte) (n int, err error) {
+	return m.mr.Read(p)
 }


### PR DESCRIPTION
This pull request aims to optimize the LZMA2 processing in the `github.com/bodgit/sevenzip` project by enhancing the usage of `github.com/ulikunitz/xz` library for io.ByteReader. 

The current implementation doesn't fully leverage the optimizations provided by `github.com/ulikunitz/xz` due to its usage of io.MultiReader. As a result, the proposed change modifies the code to return a custom implementation of multiReader based on io.ReadCloser when io.ByteReader is implemented.

The optimized multiReader implementation exhibits significant performance improvements, especially when handling large 7z archives. While the impact might be limited for smaller inputs, it can provide an efficiency boost of nearly 10% for larger files.

before:
```
goos: linux
goarch: amd64
pkg: github.com/bodgit/sevenzip
cpu: Intel(R) Core(TM) i7-8650U CPU @ 1.90GHz
BenchmarkLargeLZMA2-8   	       1	323613023997 ns/op
BenchmarkLZMA2-8        	     816	   1648719 ns/o
```

after:
```
goos: linux
goarch: amd64
pkg: github.com/bodgit/sevenzip
cpu: Intel(R) Core(TM) i7-8650U CPU @ 1.90GHz
BenchmarkLargeLZMA2-8   	       1	307210122907 ns/op
BenchmarkLZMA2-8        	     926	   1512918 ns/op
```

I kindly request your review and feedback on this pull request. Thank you for considering this contribution.