### PR TITLE
Turn off depguard lint check

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -10,7 +10,6 @@ linters:
     - contextcheck
     - cyclop
     - decorder
-    - depguard
     - dogsled
     - dupl
     - dupword


### PR DESCRIPTION
Not sure why it's suddenly started flagging imports.