### PR TITLE
ci: Drop pull_request events

### DIFF
--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -1,11 +1,6 @@
 name: Lint pull request
 
 on:
-  pull_request:
-    types:
-      - opened
-      - edited
-      - synchronize
   pull_request_target:
     types:
       - opened


### PR DESCRIPTION
No need to run on both, pull_request_target works for both local and forks.