### PR TITLE
performance optimization for extract encrypted 7z

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,23 +1,23 @@
 # Changelog
 
-## [1.5.0](https://github.com/bodgit/sevenzip/compare/v1.4.5...v1.5.0) (2024-02-08)
+## [1.5.0](https://github.com/gooxion/sevenzip/compare/v1.4.5...v1.5.0) (2024-02-08)
 
 
 ### Features
 
-* Export the folder/stream identifier ([#169](https://github.com/bodgit/sevenzip/issues/169)) ([187a49e](https://github.com/bodgit/sevenzip/commit/187a49e243ec0618b527851fcee0503d8436e7c2))
+* Export the folder/stream identifier ([#169](https://github.com/gooxion/sevenzip/issues/169)) ([187a49e](https://github.com/gooxion/sevenzip/commit/187a49e243ec0618b527851fcee0503d8436e7c2))
 
-## [1.4.5](https://github.com/bodgit/sevenzip/compare/v1.4.4...v1.4.5) (2023-12-12)
-
-
-### Bug Fixes
-
-* Handle lack of CRC digests ([#143](https://github.com/bodgit/sevenzip/issues/143)) ([4ead944](https://github.com/bodgit/sevenzip/commit/4ead944ad71398931b70a09ea40ba9ce742f4bf7))
-* Handle small reads in branch converters ([#144](https://github.com/bodgit/sevenzip/issues/144)) ([dfaf538](https://github.com/bodgit/sevenzip/commit/dfaf538402be45e6cd12064b3d49e7496d2b22f4))
-
-## [1.4.4](https://github.com/bodgit/sevenzip/compare/v1.4.3...v1.4.4) (2023-11-06)
+## [1.4.5](https://github.com/gooxion/sevenzip/compare/v1.4.4...v1.4.5) (2023-12-12)
 
 
 ### Bug Fixes
 
-* Handle panic when unpack info is missing ([#117](https://github.com/bodgit/sevenzip/issues/117)) ([db3ba77](https://github.com/bodgit/sevenzip/commit/db3ba775286aa4efce8fdd1c398bf2bd4dfba37d))
+* Handle lack of CRC digests ([#143](https://github.com/gooxion/sevenzip/issues/143)) ([4ead944](https://github.com/gooxion/sevenzip/commit/4ead944ad71398931b70a09ea40ba9ce742f4bf7))
+* Handle small reads in branch converters ([#144](https://github.com/gooxion/sevenzip/issues/144)) ([dfaf538](https://github.com/gooxion/sevenzip/commit/dfaf538402be45e6cd12064b3d49e7496d2b22f4))
+
+## [1.4.4](https://github.com/gooxion/sevenzip/compare/v1.4.3...v1.4.4) (2023-11-06)
+
+
+### Bug Fixes
+
+* Handle panic when unpack info is missing ([#117](https://github.com/gooxion/sevenzip/issues/117)) ([db3ba77](https://github.com/gooxion/sevenzip/commit/db3ba775286aa4efce8fdd1c398bf2bd4dfba37d))

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/bodgit/sevenzip/badge)](https://securityscorecards.dev/viewer/?uri=github.com/bodgit/sevenzip)
+[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/gooxion/sevenzip/badge)](https://securityscorecards.dev/viewer/?uri=github.com/gooxion/sevenzip)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/6882/badge)](https://www.bestpractices.dev/projects/6882)
-[![GitHub release](https://img.shields.io/github/v/release/bodgit/sevenzip)](https://github.com/bodgit/sevenzip/releases)
-[![Build Status](https://img.shields.io/github/actions/workflow/status/bodgit/sevenzip/build.yml?branch=main)](https://github.com/bodgit/sevenzip/actions?query=workflow%3ABuild)
-[![Coverage Status](https://coveralls.io/repos/github/bodgit/sevenzip/badge.svg?branch=master)](https://coveralls.io/github/bodgit/sevenzip?branch=master)
-[![Go Report Card](https://goreportcard.com/badge/github.com/bodgit/sevenzip)](https://goreportcard.com/report/github.com/bodgit/sevenzip)
-[![GoDoc](https://godoc.org/github.com/bodgit/sevenzip?status.svg)](https://godoc.org/github.com/bodgit/sevenzip)
+[![GitHub release](https://img.shields.io/github/v/release/gooxion/sevenzip)](https://github.com/gooxion/sevenzip/releases)
+[![Build Status](https://img.shields.io/github/actions/workflow/status/gooxion/sevenzip/build.yml?branch=main)](https://github.com/gooxion/sevenzip/actions?query=workflow%3ABuild)
+[![Coverage Status](https://coveralls.io/repos/github/gooxion/sevenzip/badge.svg?branch=master)](https://coveralls.io/github/gooxion/sevenzip?branch=master)
+[![Go Report Card](https://goreportcard.com/badge/github.com/gooxion/sevenzip)](https://goreportcard.com/report/github.com/gooxion/sevenzip)
+[![GoDoc](https://godoc.org/github.com/gooxion/sevenzip?status.svg)](https://godoc.org/github.com/gooxion/sevenzip)
 ![Go version](https://img.shields.io/badge/Go-1.22-brightgreen.svg)
 ![Go version](https://img.shields.io/badge/Go-1.21-brightgreen.svg)
 
@@ -95,7 +95,7 @@ There is a set of benchmarks in this package that demonstrates the performance b
 $ go test -v -run='^$' -bench='Reader$' -benchtime=60s
 goos: darwin
 goarch: amd64
-pkg: github.com/bodgit/sevenzip
+pkg: github.com/gooxion/sevenzip
 cpu: Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 BenchmarkNaiveReader
 BenchmarkNaiveReader-12                  	       2	31077542628 ns/op
@@ -108,7 +108,7 @@ BenchmarkNaiveSingleParallelReader-12    	     412	 171027895 ns/op
 BenchmarkParallelReader
 BenchmarkParallelReader-12               	     636	 112551812 ns/op
 PASS
-ok  	github.com/bodgit/sevenzip	472.251s
+ok  	github.com/gooxion/sevenzip	472.251s
 ```
 The archive used here is just the reference LZMA SDK archive, which is only 1 MiB in size but does contain 630+ files split across three compression streams.
 The only difference between BenchmarkNaiveReader and the rest is the lack of a call to `rc.Close()` between files so the stream reuse optimisation doesn't take effect.

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/bodgit/sevenzip
+module github.com/gooxion/sevenzip
 
 go 1.19
 

--- a/internal/aes7z/key.go
+++ b/internal/aes7z/key.go
@@ -4,12 +4,50 @@ import (
 	"bytes"
 	"crypto/sha256"
 	"encoding/binary"
+	"sync"
 
 	"golang.org/x/text/encoding/unicode"
 	"golang.org/x/text/transform"
 )
 
+type keyCacheItem struct {
+	password string
+	cycles   int
+	salt     []byte
+	key      []byte
+}
+
+func (c *keyCacheItem) hittest(password string, cycles int, salt []byte) bool {
+	return c.password == password && c.cycles == cycles && bytes.Equal(salt, c.salt)
+}
+
+var keyCache []*keyCacheItem = []*keyCacheItem{}
+var keyCacheLock sync.RWMutex
+
+func findKeyCached(password string, cycles int, salt []byte) []byte {
+	keyCacheLock.RLock()
+	defer keyCacheLock.RUnlock()
+	for _, kci := range keyCache {
+		if kci.hittest(password, cycles, salt) {
+			return kci.key
+		}
+	}
+
+	return nil
+}
+
+func recordKeyCached(password string, cycles int, salt []byte, key []byte) {
+	keyCacheLock.Lock()
+	defer keyCacheLock.Unlock()
+	keyCache = append(keyCache, &keyCacheItem{password: password, cycles: cycles, salt: salt, key: key})
+}
+
 func calculateKey(password string, cycles int, salt []byte) []byte {
+	k := findKeyCached(password, cycles, salt)
+	if len(k) > 0 {
+		// key found in cache
+		return k
+	}
 	b := bytes.NewBuffer(salt)
 
 	// Convert password to UTF-16LE
@@ -30,5 +68,6 @@ func calculateKey(password string, cycles int, salt []byte) []byte {
 		copy(key, h.Sum(nil))
 	}
 
+	recordKeyCached(password, cycles, salt, key)
 	return key
 }

--- a/internal/bcj2/reader.go
+++ b/internal/bcj2/reader.go
@@ -6,7 +6,7 @@ import (
 	"errors"
 	"io"
 
-	"github.com/bodgit/sevenzip/internal/util"
+	"github.com/gooxion/sevenzip/internal/util"
 	"github.com/hashicorp/go-multierror"
 )
 

--- a/internal/deflate/reader.go
+++ b/internal/deflate/reader.go
@@ -5,7 +5,7 @@ import (
 	"io"
 	"sync"
 
-	"github.com/bodgit/sevenzip/internal/util"
+	"github.com/gooxion/sevenzip/internal/util"
 	"github.com/klauspost/compress/flate"
 )
 

--- a/internal/pool/pool.go
+++ b/internal/pool/pool.go
@@ -6,7 +6,7 @@ import (
 	"sort"
 	"sync"
 
-	"github.com/bodgit/sevenzip/internal/util"
+	"github.com/gooxion/sevenzip/internal/util"
 )
 
 // Pooler is the interface implemented by a pool.

--- a/reader.go
+++ b/reader.go
@@ -18,8 +18,8 @@ import (
 	"time"
 
 	"github.com/bodgit/plumbing"
-	"github.com/bodgit/sevenzip/internal/pool"
-	"github.com/bodgit/sevenzip/internal/util"
+	"github.com/gooxion/sevenzip/internal/pool"
+	"github.com/gooxion/sevenzip/internal/util"
 	"github.com/hashicorp/go-multierror"
 	"go4.org/readerutil"
 )

--- a/reader_test.go
+++ b/reader_test.go
@@ -12,8 +12,8 @@ import (
 	"testing/fstest"
 	"testing/iotest"
 
-	"github.com/bodgit/sevenzip"
-	"github.com/bodgit/sevenzip/internal/util"
+	"github.com/gooxion/sevenzip"
+	"github.com/gooxion/sevenzip/internal/util"
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/sync/errgroup"
 )

--- a/register.go
+++ b/register.go
@@ -5,17 +5,17 @@ import (
 	"io"
 	"sync"
 
-	"github.com/bodgit/sevenzip/internal/aes7z"
-	"github.com/bodgit/sevenzip/internal/bcj2"
-	"github.com/bodgit/sevenzip/internal/bra"
-	"github.com/bodgit/sevenzip/internal/brotli"
-	"github.com/bodgit/sevenzip/internal/bzip2"
-	"github.com/bodgit/sevenzip/internal/deflate"
-	"github.com/bodgit/sevenzip/internal/delta"
-	"github.com/bodgit/sevenzip/internal/lz4"
-	"github.com/bodgit/sevenzip/internal/lzma"
-	"github.com/bodgit/sevenzip/internal/lzma2"
-	"github.com/bodgit/sevenzip/internal/zstd"
+	"github.com/gooxion/sevenzip/internal/aes7z"
+	"github.com/gooxion/sevenzip/internal/bcj2"
+	"github.com/gooxion/sevenzip/internal/bra"
+	"github.com/gooxion/sevenzip/internal/brotli"
+	"github.com/gooxion/sevenzip/internal/bzip2"
+	"github.com/gooxion/sevenzip/internal/deflate"
+	"github.com/gooxion/sevenzip/internal/delta"
+	"github.com/gooxion/sevenzip/internal/lz4"
+	"github.com/gooxion/sevenzip/internal/lzma"
+	"github.com/gooxion/sevenzip/internal/lzma2"
+	"github.com/gooxion/sevenzip/internal/zstd"
 )
 
 // Decompressor describes the function signature that decompression/decryption

--- a/struct.go
+++ b/struct.go
@@ -11,7 +11,7 @@ import (
 	"time"
 
 	"github.com/bodgit/plumbing"
-	"github.com/bodgit/sevenzip/internal/util"
+	"github.com/gooxion/sevenzip/internal/util"
 )
 
 var errAlgorithm = errors.New("sevenzip: unsupported compression algorithm")

--- a/types.go
+++ b/types.go
@@ -10,8 +10,8 @@ import (
 	"math/bits"
 	"time"
 
-	"github.com/bodgit/sevenzip/internal/util"
 	"github.com/bodgit/windows"
+	"github.com/gooxion/sevenzip/internal/util"
 	"golang.org/x/text/encoding/unicode"
 	"golang.org/x/text/transform"
 )


### PR DESCRIPTION
extract encrypted 7z file need call sevenz.File.Open on each file, if 7z was encrypted, this will calculate key each time, this caused low performance,  it's terrible if many files in 7z
In fact, all files in a 7z has same key, so can cahced key on calculate key, the key will get directly from cache next time to calculate