### PR TITLE
fix: Make it possible to override decompressor for existing method

### DIFF
--- a/register.go
+++ b/register.go
@@ -75,9 +75,7 @@ func init() {
 
 // RegisterDecompressor allows custom decompressors for a specified method ID.
 func RegisterDecompressor(method []byte, dcomp Decompressor) {
-	if _, dup := decompressors.LoadOrStore(string(method), dcomp); dup {
-		panic("decompressor already registered")
-	}
+	decompressors.Store(string(method), dcomp)
 }
 
 func decompressor(method []byte) Decompressor {


### PR DESCRIPTION
Hi.

I have [own decompressor](https://github.com/kulaginds/lzma) for lzma/lzma2, but it unstable yet.
I want to register it for my project, but can't [because of panic](https://github.com/bodgit/sevenzip/blob/9e24d3164c3e4ca7a66c87ba49c473aca6ab7e3c/register.go#L79).

Have a reason why cannot override existed decompressor for method?