### PR TITLE
fix: protect against specially crafted archives setting high AES cycles

### DIFF
--- a/internal/aes7z/export_test.go
+++ b/internal/aes7z/export_test.go
@@ -1,0 +1,3 @@
+package aes7z
+
+var ErrCyclesPowerTooLarge = errCyclesPowerTooLarge

--- a/internal/aes7z/key.go
+++ b/internal/aes7z/key.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"encoding/binary"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"sync"
 
@@ -19,7 +20,18 @@ type cacheKey struct {
 	salt     string // []byte isn't comparable
 }
 
-const cacheSize = 10
+const (
+	cacheSize = 10
+
+	// maxCyclesPower caps the KDF iteration exponent to prevent CPU exhaustion
+	// from malicious archives. Standard 7-zip always uses 19 (≈500K rounds,
+	// ~10ms). A cap of 24 (≈16M rounds, ~250ms) provides 32× headroom above
+	// the standard while keeping the worst-case derivation time bounded.
+	// The special value 0x3f bypasses hashing entirely and is not affected.
+	maxCyclesPower = 24
+)
+
+var errCyclesPowerTooLarge = errors.New("aes7z: cycles power exceeds maximum")
 
 //nolint:gochecknoglobals
 var once = sync.OnceValues(func() (*lru.Cache[cacheKey, []byte], error) {
@@ -51,8 +63,13 @@ func calculateKey(password string, cycles int, salt []byte) ([]byte, error) {
 
 	key := make([]byte, sha256.Size)
 	if cycles == 0x3f {
+		// Raw mode: key is derived directly from salt+password, no hashing.
 		copy(key, b.Bytes())
 	} else {
+		if cycles > maxCyclesPower {
+			return nil, fmt.Errorf("%w: %d > %d", errCyclesPowerTooLarge, cycles, maxCyclesPower)
+		}
+
 		h := sha256.New()
 		for i := range uint64(1 << cycles) {
 			// These will never error

--- a/internal/aes7z/reader_test.go
+++ b/internal/aes7z/reader_test.go
@@ -1,0 +1,79 @@
+package aes7z_test
+
+import (
+	"bytes"
+	"io"
+	"testing"
+
+	"github.com/bodgit/sevenzip/internal/aes7z"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// passwordSetter matches the Password method on the AES reader without
+// importing the parent package (which would be circular).
+type passwordSetter interface {
+	Password(p string) error
+}
+
+func TestPassword(t *testing.T) {
+	t.Parallel()
+
+	tables := []struct {
+		name    string
+		cycles  byte
+		wantErr error
+	}{
+		{
+			name:   "low cycles (0)",
+			cycles: 0,
+		},
+		{
+			name:   "standard cycles (19)",
+			cycles: 19,
+		},
+		{
+			name:   "at cap (24)",
+			cycles: 24,
+		},
+		{
+			name:    "one above cap (25)",
+			cycles:  25,
+			wantErr: aes7z.ErrCyclesPowerTooLarge,
+		},
+		{
+			name:    "high cycles (62)",
+			cycles:  62,
+			wantErr: aes7z.ErrCyclesPowerTooLarge,
+		},
+		{
+			name:   "raw mode (0x3f, no hashing)",
+			cycles: 0x3f,
+		},
+	}
+
+	for _, table := range tables {
+		t.Run(table.name, func(t *testing.T) {
+			t.Parallel()
+
+			p := []byte{0x80 | table.cycles, 0x00, 0x00}
+			rc, err := aes7z.NewReader(p, 0, []io.ReadCloser{io.NopCloser(bytes.NewReader(nil))})
+			require.NoError(t, err)
+
+			defer func() {
+				require.NoError(t, rc.Close())
+			}()
+
+			ps, ok := rc.(passwordSetter)
+			require.True(t, ok)
+
+			err = ps.Password("password")
+
+			if table.wantErr == nil {
+				assert.NoError(t, err)
+			} else {
+				assert.ErrorIs(t, err, table.wantErr)
+			}
+		})
+	}
+}

--- a/reader_test.go
+++ b/reader_test.go
@@ -27,12 +27,6 @@ func reader(r io.Reader) io.Reader {
 	return r
 }
 
-const (
-	noHeaderCompression = "no header compression"
-	t0Filename          = "t0.7z"
-	testPassword        = "password"
-)
-
 var errCRCMismatch = errors.New("CRC doesn't match")
 
 func extractFile(tb testing.TB, r io.Reader, h hash.Hash, f *sevenzip.File) error {
@@ -101,8 +95,8 @@ func TestOpenReader(t *testing.T) {
 		err        error
 	}{
 		{
-			name: noHeaderCompression,
-			file: t0Filename,
+			name: "no header compression",
+			file: "t0.7z",
 		},
 		{
 			name: "with header compression",
@@ -260,24 +254,24 @@ func TestOpenReaderWithPassword(t *testing.T) {
 		name, file, password string
 	}{
 		{
-			name:     noHeaderCompression,
+			name:     "no header compression",
 			file:     "t2.7z",
-			password: testPassword,
+			password: "password",
 		},
 		{
 			name:     "with header compression",
 			file:     "t3.7z",
-			password: testPassword,
+			password: "password",
 		},
 		{
 			name:     "unencrypted headers compressed files",
 			file:     "t4.7z",
-			password: testPassword,
+			password: "password",
 		},
 		{
 			name:     "unencrypted headers uncompressed files",
 			file:     "t5.7z",
-			password: testPassword,
+			password: "password",
 		},
 		{
 			name:     "issue 75",
@@ -364,12 +358,12 @@ func TestNewReader(t *testing.T) {
 		err        error
 	}{
 		{
-			name: noHeaderCompression,
-			file: t0Filename,
+			name: "no header compression",
+			file: "t0.7z",
 		},
 		{
-			name: noHeaderCompression,
-			file: t0Filename,
+			name: "no header compression",
+			file: "t0.7z",
 			size: -1,
 			err:  sevenzip.ErrNegativeSize,
 		},
@@ -595,7 +589,7 @@ func benchmarkArchive(b *testing.B, file, password string, optimised bool) {
 }
 
 func BenchmarkAES7z(b *testing.B) {
-	benchmarkArchive(b, "aes7z.7z", testPassword, true)
+	benchmarkArchive(b, "aes7z.7z", "password", true)
 }
 
 func BenchmarkBzip2(b *testing.B) {

--- a/reader_test.go
+++ b/reader_test.go
@@ -27,6 +27,12 @@ func reader(r io.Reader) io.Reader {
 	return r
 }
 
+const (
+	noHeaderCompression = "no header compression"
+	t0Filename          = "t0.7z"
+	testPassword        = "password"
+)
+
 var errCRCMismatch = errors.New("CRC doesn't match")
 
 func extractFile(tb testing.TB, r io.Reader, h hash.Hash, f *sevenzip.File) error {
@@ -95,8 +101,8 @@ func TestOpenReader(t *testing.T) {
 		err        error
 	}{
 		{
-			name: "no header compression",
-			file: "t0.7z",
+			name: noHeaderCompression,
+			file: t0Filename,
 		},
 		{
 			name: "with header compression",
@@ -254,24 +260,24 @@ func TestOpenReaderWithPassword(t *testing.T) {
 		name, file, password string
 	}{
 		{
-			name:     "no header compression",
+			name:     noHeaderCompression,
 			file:     "t2.7z",
-			password: "password",
+			password: testPassword,
 		},
 		{
 			name:     "with header compression",
 			file:     "t3.7z",
-			password: "password",
+			password: testPassword,
 		},
 		{
 			name:     "unencrypted headers compressed files",
 			file:     "t4.7z",
-			password: "password",
+			password: testPassword,
 		},
 		{
 			name:     "unencrypted headers uncompressed files",
 			file:     "t5.7z",
-			password: "password",
+			password: testPassword,
 		},
 		{
 			name:     "issue 75",
@@ -358,12 +364,12 @@ func TestNewReader(t *testing.T) {
 		err        error
 	}{
 		{
-			name: "no header compression",
-			file: "t0.7z",
+			name: noHeaderCompression,
+			file: t0Filename,
 		},
 		{
-			name: "no header compression",
-			file: "t0.7z",
+			name: noHeaderCompression,
+			file: t0Filename,
 			size: -1,
 			err:  sevenzip.ErrNegativeSize,
 		},
@@ -589,7 +595,7 @@ func benchmarkArchive(b *testing.B, file, password string, optimised bool) {
 }
 
 func BenchmarkAES7z(b *testing.B) {
-	benchmarkArchive(b, "aes7z.7z", "password", true)
+	benchmarkArchive(b, "aes7z.7z", testPassword, true)
 }
 
 func BenchmarkBzip2(b *testing.B) {


### PR DESCRIPTION
add maxCyclesPower to cap the number of cycles.
add tests to validate behavior

Cycles setting comes directly from the archive's AES properties byte
which could be set to something like cycles=62 which would mean 2^62 ≈
4.6×10^18 SHA-256 iterations, which would effectively hang the process.
Standard 7-zip archives use cycles=19 so setting the cap to 24 gives
headroom to the standard while still protecting from a malicious file